### PR TITLE
Validate Shelly IP via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ note: relay 1 in the gui is relay 0 on the DBUS
 The other script is to start it on boot
 
 First create a file named: shelly-follow-relay0.py
-1. nano /data/shelly-follow-relay0.py
+1. `nano /data/shelly-follow-relay0.py`
 2. paste the script from this repo
-3. make it executable: chmod +x /data/shelly-follow-relay0.py
-4. Now create a boot script: nano /data/rc.local
-5. Paste the boot script from this repo
-6. make it executable: chmod +x /data/rc.local
+3. make it executable: `chmod +x /data/shelly-follow-relay0.py`
+4. export the Shelly IP address so the script knows where to send
+   commands, e.g. `export SHELLY_IP=192.0.2.10`
+5. Now create a boot script: `nano /data/rc.local`
+6. Paste the boot script from this repo
+7. make it executable: `chmod +x /data/rc.local`
 reboot and try
 
  ![image](https://github.com/user-attachments/assets/27614d9f-a042-4952-916c-854ce1444856)

--- a/shelly-follow-relay0.py
+++ b/shelly-follow-relay0.py
@@ -4,9 +4,16 @@ import dbus.mainloop.glib
 from gi.repository import GLib
 import requests
 import time
+import os
 
-# Replace with your actual Shelly IP
-SHELLY_IP = "REPLACE WITH YOUR SHELLY IP"
+# Shelly device IP address must be provided via environment variable.
+# Failing to set it previously resulted in attempting to contact an
+# invalid host and silently doing nothing.  Fetch it once at startup
+# and raise an explicit error if it is missing so that configuration
+# issues are immediately visible.
+SHELLY_IP = os.getenv("SHELLY_IP")
+if not SHELLY_IP:
+    raise RuntimeError("SHELLY_IP environment variable not set")
 
 def toggle_shelly(state):
     try:


### PR DESCRIPTION
## Summary
- fail fast when `SHELLY_IP` is not set so the script no longer silently uses a placeholder address
- document the need to export `SHELLY_IP` before running the scripts

## Testing
- `python -m py_compile shelly-follow-relay0.py && echo "py_compile succeeded"`


------
https://chatgpt.com/codex/tasks/task_e_689764f75934832a88b9930e7df8ae31