### PR TITLE
Validate Shelly IP via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ note: relay 1 in the gui is relay 0 on the DBUS
 The other script is to start it on boot
 
 First create a file named: shelly-follow-relay0.py
-1. nano /data/shelly-follow-relay0.py
+1. `nano /data/shelly-follow-relay0.py`
 2. paste the script from this repo
-3. make it executable: chmod +x /data/shelly-follow-relay0.py
-4. Now create a boot script: nano /data/rc.local
-5. Paste the boot script from this repo
-6. make it executable: chmod +x /data/rc.local
+3. make it executable: `chmod +x /data/shelly-follow-relay0.py`
+4. Now create a boot script: `nano /data/rc.local`
+5. Paste the boot script from this repo and replace the placeholder IP
+   in the `export SHELLY_IP` line with your Shelly's address
+6. make it executable: `chmod +x /data/rc.local`
 reboot and try
 
  ![image](https://github.com/user-attachments/assets/27614d9f-a042-4952-916c-854ce1444856)

--- a/boot script for rc.local
+++ b/boot script for rc.local
@@ -3,5 +3,11 @@
 # Delay to allow D-Bus and networking to fully initialize
 sleep 15
 
+# Set the Shelly device IP address (replace with your device's address)
+export SHELLY_IP="192.0.2.10"
+
+# Fail fast if the IP address wasn't configured
+: "${SHELLY_IP:?SHELLY_IP environment variable not set}"
+
 # Start the Shelly relay listener in background and log output
 /usr/bin/python3 /data/shelly-follow-relay0.py >> /data/shelly-follow-relay0.log 2>&1 &

--- a/shelly-follow-relay0.py
+++ b/shelly-follow-relay0.py
@@ -4,9 +4,16 @@ import dbus.mainloop.glib
 from gi.repository import GLib
 import requests
 import time
+import os
 
-# Replace with your actual Shelly IP
-SHELLY_IP = "REPLACE WITH YOUR SHELLY IP"
+# Shelly device IP address must be provided via environment variable.
+# Failing to set it previously resulted in attempting to contact an
+# invalid host and silently doing nothing.  Fetch it once at startup
+# and raise an explicit error if it is missing so that configuration
+# issues are immediately visible.
+SHELLY_IP = os.getenv("SHELLY_IP")
+if not SHELLY_IP:
+    raise RuntimeError("SHELLY_IP environment variable not set")
 
 def toggle_shelly(state):
     try:


### PR DESCRIPTION
## Summary
- fail fast when `SHELLY_IP` is not set so the script no longer silently uses a placeholder address
- set and validate `SHELLY_IP` in the boot script for reliable startup
- document editing the boot script to include the Shelly IP

## Testing
- `python -m py_compile shelly-follow-relay0.py && echo 'py_compile succeeded'`
- `bash -n 'boot script for rc.local' && echo 'bash -n succeeded'`


------
https://chatgpt.com/codex/tasks/task_e_689764f75934832a88b9930e7df8ae31